### PR TITLE
Optional env change

### DIFF
--- a/TransitApi.Sdk/Components/RestSharpComponent.cs
+++ b/TransitApi.Sdk/Components/RestSharpComponent.cs
@@ -30,11 +30,11 @@ namespace TransportApi.Sdk.Components
             return request;
         }
 
-        public static RestClient Client(TimeSpan timeout)
+        public static RestClient Client(TimeSpan timeout, Uri platformUri)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 
-            var client = new RestClient(TransportApiClientConnection.TransportApiBaseUri);
+            var client = new RestClient(platformUri);
 
             client.Timeout = (int)timeout.TotalMilliseconds;
 

--- a/TransitApi.Sdk/Components/TransportApiComponent.cs
+++ b/TransitApi.Sdk/Components/TransportApiComponent.cs
@@ -72,7 +72,7 @@ namespace TransportApi.Sdk.Components
                 }
             };
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             string path = "journeys";
 
@@ -129,7 +129,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"journeys/{id}", token, settings.UniqueContextId);
 
@@ -193,7 +193,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"journeys/{journeyId}/itineraries/{itineraryId}", token, settings.UniqueContextId);
 
@@ -271,7 +271,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("agencies", token, settings.UniqueContextId);
 
@@ -356,7 +356,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"agencies/{id}", token, settings.UniqueContextId);
 
@@ -434,7 +434,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("stops", token, settings.UniqueContextId);
 
@@ -531,7 +531,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}", token, settings.UniqueContextId);
 
@@ -588,7 +588,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}/stops", token, settings.UniqueContextId);
 
@@ -651,7 +651,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("lines", token, settings.UniqueContextId);
 
@@ -744,7 +744,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}", token, settings.UniqueContextId);
 
@@ -807,7 +807,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}/timetables", token, settings.UniqueContextId);
 
@@ -890,7 +890,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/timetables", token, settings.UniqueContextId);
 
@@ -971,7 +971,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/shape", token, settings.UniqueContextId);
 
@@ -1028,7 +1028,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/routes", token, settings.UniqueContextId);
 
@@ -1091,7 +1091,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("fareproducts", token, settings.UniqueContextId);
 
@@ -1164,7 +1164,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"fareproducts/{id}/faretables", token, settings.UniqueContextId);
 
@@ -1229,7 +1229,7 @@ namespace TransportApi.Sdk.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"fareproducts/{id}", token, settings.UniqueContextId);
 
@@ -1265,6 +1265,5 @@ namespace TransportApi.Sdk.Components
 
             return result;
         }
-
     }
 }

--- a/TransitApi.Sdk/Properties/AssemblyInfo.cs
+++ b/TransitApi.Sdk/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.0.0")]
-[assembly: AssemblyFileVersion("2.9.0.0")]
+[assembly: AssemblyVersion("2.9.1.0")]
+[assembly: AssemblyFileVersion("2.9.1.0")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/TransitApi.Shared/AbstractTransportApiClient.cs
+++ b/TransitApi.Shared/AbstractTransportApiClient.cs
@@ -44,7 +44,6 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetAgencies(tokenComponent, settings, ct, onlyAgencies, omitAgencies, null, latitude, longitude, string.Empty, radiusInMeters, limit, offset, exclude);
         }
 
-
         /// <summary>
         /// Gets a list of all agencies in the system.
         /// </summary>
@@ -85,7 +84,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetAgency(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Agencies
 
         #region Stops
 
@@ -164,7 +163,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetChildStops(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Stops
 
         #region Lines
 
@@ -228,7 +227,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetLine(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Lines
 
         #region Journeys
 
@@ -272,7 +271,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetJourneyItinerary(tokenComponent, settings, ct, journeyId, itineraryId, null, exclude);
         }
 
-        #endregion
+        #endregion Journeys
 
         #region Timetables
 
@@ -309,7 +308,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetLineTimetable(tokenComponent, settings, ct, id, departureStopIdFilter, arrivalStopIdFilter, earliestDepartureTime, latestDepartureTime, null, limit: limit, offset: offset, exclude: exclude);
         }
 
-        #endregion
+        #endregion Timetables
 
         #region Shapes
 
@@ -324,7 +323,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetLineShape(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Shapes
 
         #region Routes
 
@@ -338,7 +337,7 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetRoutesByLine(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Routes
 
         #region Fares
 
@@ -379,6 +378,6 @@ namespace TransportApi.Sdk
             return await transitApiComponent.GetFareProduct(tokenComponent, settings, ct, id, null, exclude);
         }
 
-        #endregion
+        #endregion Fares
     }
 }

--- a/TransitApi.Shared/TransportApiClientSettings.cs
+++ b/TransitApi.Shared/TransportApiClientSettings.cs
@@ -8,6 +8,8 @@ namespace TransportApi.Sdk
         public string ClientSecret { get; set; }
         public string UniqueContextId { get; set; }
 
+        public Uri EnvironmentUri { get; set; } = TransportApiClientConnection.TransportApiBaseUri;
+
         /// <summary>
         /// Additional scopes to request.
         /// Default is transportapi:all.

--- a/TransitApi.Shared/TransportApiClientSettings.cs
+++ b/TransitApi.Shared/TransportApiClientSettings.cs
@@ -8,7 +8,7 @@ namespace TransportApi.Sdk
         public string ClientSecret { get; set; }
         public string UniqueContextId { get; set; }
 
-        public Uri EnvironmentUri { get; set; } = TransportApiClientConnection.TransportApiBaseUri;
+        public Uri EnvironmentUri { get; set; }
 
         /// <summary>
         /// Additional scopes to request.
@@ -27,6 +27,7 @@ namespace TransportApi.Sdk
             Timeout = TimeSpan.FromSeconds(30);
             ClientScopes = "transportapi:all";
             UniqueContextId = Guid.NewGuid().ToString();
+            EnvironmentUri = TransportApiClientConnection.TransportApiBaseUri;
         }
     }
 }

--- a/TransitApi.Shared/TransportApiClientSettings.cs
+++ b/TransitApi.Shared/TransportApiClientSettings.cs
@@ -7,7 +7,6 @@ namespace TransportApi.Sdk
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
         public string UniqueContextId { get; set; }
-
         public Uri EnvironmentUri { get; set; }
 
         /// <summary>

--- a/TransportApi.Sdk.NetCore/Components/RestSharpComponent.cs
+++ b/TransportApi.Sdk.NetCore/Components/RestSharpComponent.cs
@@ -29,9 +29,9 @@ namespace TransportApi.Sdk.NetCore.Components
             return request;
         }
 
-        public static RestClient Client(TimeSpan timeout)
+        public static RestClient Client(TimeSpan timeout, Uri platformUri)
         {
-            var client = new RestClient(TransportApiClientConnection.TransportApiBaseUri);
+            var client = new RestClient(platformUri);
 
             client.Timeout = (int)timeout.TotalMilliseconds;
 

--- a/TransportApi.Sdk.NetCore/Components/TransportApiComponent.cs
+++ b/TransportApi.Sdk.NetCore/Components/TransportApiComponent.cs
@@ -73,7 +73,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 }
             };
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             string path = "journeys";
 
@@ -130,7 +130,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"journeys/{id}", token, settings.UniqueContextId);
 
@@ -194,7 +194,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"journeys/{journeyId}/itineraries/{itineraryId}", token, settings.UniqueContextId);
 
@@ -272,7 +272,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("agencies", token, settings.UniqueContextId);
 
@@ -357,7 +357,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"agencies/{id}", token, settings.UniqueContextId);
 
@@ -435,7 +435,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("stops", token, settings.UniqueContextId);
 
@@ -532,7 +532,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}", token, settings.UniqueContextId);
 
@@ -589,7 +589,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}/stops", token, settings.UniqueContextId);
 
@@ -652,7 +652,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("lines", token, settings.UniqueContextId);
 
@@ -745,7 +745,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}", token, settings.UniqueContextId);
 
@@ -808,7 +808,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"stops/{id}/timetables", token, settings.UniqueContextId);
 
@@ -891,7 +891,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/timetables", token, settings.UniqueContextId);
 
@@ -972,7 +972,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/shape", token, settings.UniqueContextId);
 
@@ -1029,7 +1029,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"lines/{id}/routes", token, settings.UniqueContextId);
 
@@ -1092,7 +1092,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest("fareproducts", token, settings.UniqueContextId);
 
@@ -1165,7 +1165,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"fareproducts/{id}/faretables", token, settings.UniqueContextId);
 
@@ -1230,7 +1230,7 @@ namespace TransportApi.Sdk.NetCore.Components
                 return result;
             }
 
-            var client = Client(settings.Timeout);
+            var client = Client(settings.Timeout, settings.EnvironmentUri);
 
             var request = GetRequest($"fareproducts/{id}", token, settings.UniqueContextId);
 

--- a/TransportApi.Sdk.NetCore/TransportApi.Sdk.NetCore.csproj
+++ b/TransportApi.Sdk.NetCore/TransportApi.Sdk.NetCore.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>TransportApi.Sdk.NetCore</AssemblyName>
     <RootNamespace>TransportApi.Sdk.NetCore</RootNamespace>
     <PackageId>TransportApi.Sdk.NetCore</PackageId>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>1.3.1</PackageVersion>
     <Authors>WhereIsMyTransport Ltd.</Authors>
     <Description>.NET Core C# Sdk for the WhereIsMyTransport platform.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/TransportApi.Sdk.NetCore/TransportApi.Sdk.NetCore.csproj
+++ b/TransportApi.Sdk.NetCore/TransportApi.Sdk.NetCore.csproj
@@ -12,7 +12,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Copyright>Copyright © 2018</Copyright>
     <PackageTags>transport transit</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/14315660</PackageIconUrl>
     <RepositoryUrl></RepositoryUrl>


### PR DESCRIPTION
allows the client to be created with setting that overrides default uri (platform.whereismytransport) so we can point the sdk to some kind of test env - if we want.